### PR TITLE
Support Gnome 45

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -16,17 +16,18 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 /* exported init */
-const { GObject, St, Gio } = imports.gi
+import GObject from 'gi://GObject'
+import St from 'gi://St'
+import Gio from 'gi://Gio'
+import Clutter from 'gi://Clutter'
 
-const ExtensionUtils = imports.misc.extensionUtils
-const Main = imports.ui.main
-const PanelMenu = imports.ui.panelMenu
-const PopupMenu = imports.ui.popupMenu
-const Me = ExtensionUtils.getCurrentExtension()
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const {settingsDef} = Me.imports.settingsDef
-const SettingsManager = Me.imports.utils.SettingsManager
-const {gettext:_} = imports.gettext.domain(Me.metadata.uuid)
+import { settingsDef } from './settingsDef.js';
+import * as SettingsManager from './utils/SettingsManager.js';
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 let settingsManager
 
@@ -144,6 +145,11 @@ const makeMenuItem = (params) => {
 }
 
 const Indicator = GObject.registerClass( class Indicator extends PanelMenu.Button {
+	constructor(extension) {
+		super()
+		this._extension = extension
+	}
+
 	_init() {
 		super._init(0.0, 'Battery indicator')
 
@@ -201,7 +207,7 @@ const Indicator = GObject.registerClass( class Indicator extends PanelMenu.Butto
 					text: percentage,
 					style_class: 'battery-indicator-label',
 					style: (charging ? 'color:yellow;' : '') + (reliable ? '' : 'font-style:italic;'),
-					y_align: St.Align.END
+					y_align: Clutter.ActorAlign.CENTER
 				})
 				container.add_child(icon)
 				container.add_child(label)
@@ -256,26 +262,27 @@ const Indicator = GObject.registerClass( class Indicator extends PanelMenu.Butto
 		this.menu.addMenuItem(makeMenuItem({
 			label: _('Settings'),
 			icon: 'preferences-other',
-			onActivate: () =>  ExtensionUtils.openPrefs?.()
+			onActivate: () =>  this._extension.openPreferences?.()
 		}))
 	}
 
 })
 
-class Extension {
-	constructor(uuid) {
-		this._uuid = uuid
-		ExtensionUtils.initTranslations(uuid)
+export default class BatteryExtension extends Extension {
+	constructor(metadata) {
+        super(metadata);
+		this._uuid = metadata.uuid
+		this.initTranslations(metadata.uuid)
 	}
 
 	enable() {
-		const indicator = new Indicator()
+		const indicator = new Indicator(this)
 		this._indicator = indicator
 		settingsManager = SettingsManager.init(
 			'org.gnome.shell.extensions.battery-indicator-upower',
 			settingsDef
 		)._startListening()
-		indicator.refreshIndicator()
+		indicator.refreshIndicator().catch(e => { logError(e, 'refresh in enable')})
 		this._settingObserver = settingsManager.addChangeObserver(() => {
 			indicator.refreshIndicator()
 		})
@@ -296,5 +303,5 @@ class Extension {
 }
 
 function init(meta) {
-	return new Extension(meta.uuid)
+	return new BatteryExtension(meta.uuid)
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,6 +5,6 @@
   "settings-schema": "org.gnome.shell.extensions.battery-indicator-upower",
   "url":"https://github.com/malko/battery-indicator-upower",
   "shell-version": [
-    "42", "43"
+    "45"
   ]
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -15,22 +15,12 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
-const {Adw, GLib, Gtk, Gio} = imports.gi
+import Adw from 'gi://Adw'
+import Gtk from 'gi://Gtk'
+import Gio from 'gi://Gio'
 
 // It's common practice to keep GNOME API and JS imports in separate blocks
-const ExtensionUtils = imports.misc.extensionUtils
-const Me = ExtensionUtils.getCurrentExtension()
-const {gettext:_} = imports.gettext.domain(Me.metadata.uuid)
-
-
-/**
- * Like `extension.js` this is used for any one-time setup like translations.
- *
- * @param {ExtensionMeta} meta - An extension meta object, described below.
- */
-function init(meta) {
-	ExtensionUtils.initTranslations(Me.metadata.uuid)
-}
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const makeActionSwitchRow = ({title, subtitle, settingsProp}, gsettings) => {
 	const row = new Adw.ActionRow({title, subtitle})
@@ -47,6 +37,12 @@ const makeActionSwitchRow = ({title, subtitle, settingsProp}, gsettings) => {
 	return row
 }
 
+export default class MyExtensionPreferences extends ExtensionPreferences {
+	constructor(metadata) {
+        super(metadata);
+
+        this.initTranslations(metadata.uuid);
+    }
 /**
  * This function is called when the preferences window is first created to fill
  * the `Adw.PreferencesWindow`.
@@ -56,20 +52,23 @@ const makeActionSwitchRow = ({title, subtitle, settingsProp}, gsettings) => {
  *
  * @param {Adw.PreferencesWindow} window - The preferences window
  */
-function fillPreferencesWindow(window) {
-	const settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.battery-indicator-upower')
+fillPreferencesWindow(window) {
+	window._settings = this.getSettings();
+	const settings = this.getSettings();
 	const prefsPage = new Adw.PreferencesPage({
 		name: 'general',
 		title: _('General'),
 		icon_name: 'preferences-other-symbolic',
 	})
-	window.add(prefsPage)
 
 	const prefsGroup = new Adw.PreferencesGroup({
 		title: _('Global Settings'),
 		// description: `Configure ${Me.metadata.name} behaviour`,
 	})
 	prefsPage.add(prefsGroup)
+
+	window.add(prefsPage)
+
 	//-- automatic refresh interval
 	const refreshIntervalEntry = new Gtk.SpinButton({
 		valign: Gtk.Align.CENTER,
@@ -117,4 +116,5 @@ function fillPreferencesWindow(window) {
 		settingsProp: 'symbolic-icons'
 	}, settings)
 	prefsGroup.add(useSymbolicIconsRow)
+}
 }

--- a/src/settingsDef.js
+++ b/src/settingsDef.js
@@ -1,4 +1,4 @@
-var settingsDef = [
+export const settingsDef = [
 	{key: 'refresh-interval', type: 'uint', dflt: 300},
 	{key: 'refresh-menuitem', type: 'boolean', dflt: true},
 	{key: 'settings-menuitem', type: 'boolean', dflt: true},

--- a/src/utils/SettingsManager.js
+++ b/src/utils/SettingsManager.js
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
-const ExtensionUtils = imports.misc.extensionUtils;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 class SettingsManagerClass {
 	constructor(settingId, settingsDef) {
@@ -28,7 +28,7 @@ class SettingsManagerClass {
 			def[cur.key] = cur
 			return def
 		}, {})
-		this._gsettings = ExtensionUtils.getSettings(settingId)
+		this._gsettings = Extension.lookupByUUID('battery-indicator@jgotti.org').getSettings(settingId)
 	}
 
 	_startListening() {
@@ -106,4 +106,4 @@ class SettingsManagerClass {
 	}
 }
 
-var init = (...args) => new SettingsManagerClass(...args)
+export var init = (...args) => new SettingsManagerClass(...args)


### PR DESCRIPTION
Note that this *removes* support for earlier versions, as is necessary per Gnome's docs: https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version